### PR TITLE
fix demo due to webpage change

### DIFF
--- a/demo/tripadvisor.R
+++ b/demo/tripadvisor.R
@@ -31,7 +31,7 @@ date <- reviews %>%
   as.POSIXct()
 
 review <- reviews %>%
-  html_node(".partial_entry") %>%
+  html_node(".entry .partial_entry") %>%
   html_text()
 
 data.frame(id, quote, rating, date, review, stringsAsFactors = FALSE) %>% View()


### PR DESCRIPTION
The demo `trpadvisor.R` seems not to work for me in the last line. All previous scraping lines works fine but `review` gets 19 elements instead of 10.

``` rconsole
> data.frame(id, quote, rating, date, review, stringsAsFactors = FALSE) %>% View()
Error in data.frame(id, quote, rating, date, review, stringsAsFactors = FALSE) : 
  arguments imply differing number of rows: 10, 19
```

I visit the webpage and found that `.partial_entry` will not only select review but also their responses. As a result, `review` may have more than 10 entries (19 entries currently). `.entry .partial_entry` selector will fix the problem by only selecting reviews.
