### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rvest
 Title: Easily Harvest (Scrape) Web Pages
 Version: 0.1.0.9000
-Authors@R: 'Hadley Wickham <h.wickham@gmail.com> [aut,cre]'
+Authors@R: c(person("Hadley", "Wickham", email = "h.wickham@gmail.com", role = c("aut", "cre")))
 Description: Wrappers around the XML and httr packages to make it easy to
     download, then manipulation html pages.
 Depends:


### PR DESCRIPTION
In the previous version when cited in BibTex the citation comes out: 

> Wickham’, H. (2014)

with an unnecessary `'`.
