### PR TITLE
Unlist request values of length > 1 before submitting form.

### DIFF
--- a/R/form.R
+++ b/R/form.R
@@ -267,7 +267,7 @@ submit_form <- function(session, form, submit = NULL, ...) {
 
   # Unlist values in case of multiple select
   values <- request$values
-  values_length <- sapply(values, length)
+  values_length <- vapply(values, length, numeric(1))
   if (any(values_length > 1)) {
     names <- rep(names(values), values_length)
     values <- unlist(values, use.names=FALSE)

--- a/R/form.R
+++ b/R/form.R
@@ -265,11 +265,21 @@ submit_form <- function(session, form, submit = NULL, ...) {
   request <- submit_request(form, submit)
   url <- xml2::url_absolute(form$url, session$url)
 
+  # Unlist values in case of multiple select
+  values <- request$values
+  values_length <- sapply(values, length)
+  if (any(values_length > 1)) {
+    names <- rep(names(values), values_length)
+    values <- unlist(values, use.names=FALSE)
+    names(values) <- names
+    values <- as.list(values)
+  }
+
   # Make request
   if (request$method == "GET") {
-    request_GET(session, url = url, query = request$values, ...)
+    request_GET(session, url = url, query = values, ...)
   } else if (request$method == "POST") {
-    request_POST(session, url = url, body = request$values,
+    request_POST(session, url = url, body = values,
       encode = request$encode, ...)
   } else {
     stop("Unknown method: ", request$method, call. = FALSE)


### PR DESCRIPTION
Suppose I want to submit a form with a `<select>` that allows multiple selection, such as [this one](http://www.w3schools.com/tags/tryit.asp?filename=tryhtml_select_multiple). I can do it with `rvest`, but it fails if I want to select more than one `<option>` : 

``` r
library(rvest)
s <- html_session("http://www.w3schools.com/tags")
forms <- s %>% 
  jump_to('tryit.asp?filename=tryhtml_select_multiple') %>% 
  read_html() %>% html_form()
f <- set_values(forms[[1]], cars = c("volvo", "saab"))
submit_form(s,f)
```

Which gives  

```
Error in vapply(elements, encode, character(1)) : 
  values must be length 1,
 but FUN(X[[1]]) result is length 2
```

One solution seems to `unlist` the list of request values from this : 

``` r
$cars
[1] "volvo" "saab" 
```

to this : 

``` r
$cars
[1] "volvo"

$cars
[1] "saab"
```

That is the goal of this PR, which checks if one of the request values has a length > 1, and if it is TRUE, unlist these values while preserving original names.
