### PR TITLE
Improved checkboxes and radio buttons handling

### DIFF
--- a/R/form.R
+++ b/R/form.R
@@ -260,7 +260,7 @@ set_checkbox <- function(form, values) {
     
   for (i in unname(idx)) {
     if (!is.null(form$fields[[i]]$value) && (form$fields[[i]]$value %in% values))
-      form$fields[[i]]$checked <- "true"
+      form$fields[[i]]$checked <- "checked"
   }
   return(form)
 }
@@ -338,7 +338,7 @@ submit_request <- function(form, submit = NULL) {
 
   fields <- form$fields
   fields <- Filter(function(x) length(x$value) > 0, fields)
-  fields <- Filter(function(x) is.null(x$type) || ((x$type != "radio") && (x$type != "checkbox")) || (!is.null(x$type) && (x$type %in% c("checkbox", "radio")) && !is.null(x$checked) && (x$checked == "true")), fields)
+  fields <- Filter(function(x) is.null(x$type) || ((x$type != "radio") && (x$type != "checkbox")) || (!is.null(x$type) && (x$type %in% c("checkbox", "radio")) && !is.null(x$checked) && (x$checked == "true" || x$checked == "checked")), fields)
   fields <- fields[setdiff(names(fields), other_submits)]
 
   values <- pluck(fields, "value")


### PR DESCRIPTION
Improved checkboxes and radio buttons handling in set_values and submit_request.

Namely, now set_values turns the 'checked' field (in the form$fields list) to "true" when the value is the correct one. Accordingly, submit_request acknowledge the checkbox values only when 'checked' is set to "true" (for radio buttons, other options are set to "false").

This submission also allows better handling of checkbox forms where the same name is used for multiple "checks" and different values should be set altogether (e.g. "name"="foo_value1", "name"="foo_value2", etc.).

Code has been tested on several online forms with no apparent issue, e.g.
- wikipedia advanced search for testing forms with separate checkbox names,
- IMDB advanced search for forms with checkboxes sharing the same name for multiple options.

NOTE: I tried to follow Hadley's code style, but there might be space for further cleanup: please let me know whether anything is necessary before accepting the pull request or if you can take care of such thing...
