### PR TITLE
set locale if not English (especially korean) to english to bypass table encoding error

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -55,7 +55,7 @@ html_table.xml_node <- function(x, header = NA, trim = TRUE,
                                               fill = FALSE, dec = ".") {
 
   if(identical(grep("English",Sys.getlocale()),integer(0))){
-    lang<-strsplit(tem,"[=;._]")[[1]]
+    lang<-strsplit(Sys.getlocale(),"[=;._]")[[1]]
     lang<-lang[length(lang)-2]
     Sys.setlocale("LC_ALL", "English")
     lang_set<-1}else{lang_set<-0}

--- a/R/table.R
+++ b/R/table.R
@@ -54,6 +54,8 @@ html_table.xml_nodeset <- function(x, header = NA, trim = TRUE, fill = FALSE,
 html_table.xml_node <- function(x, header = NA, trim = TRUE,
                                               fill = FALSE, dec = ".") {
 
+  if(grep("Korean",Sys.getlocale())==1){Sys.setlocale("LC_ALL", "English");korean_set<-1}else{korean_set<-0}
+
   stopifnot(html_name(x) == "table")
 
   # Throw error if any rowspan/colspan present
@@ -134,6 +136,6 @@ html_table.xml_node <- function(x, header = NA, trim = TRUE,
   if (length(unique(col_names)) < length(col_names)) {
     warning('At least two columns have the same name')
   }
-
+  if(korean_set==1){Sys.setlocale("LC_ALL", "Korean")}
   df
 }

--- a/R/table.R
+++ b/R/table.R
@@ -54,7 +54,11 @@ html_table.xml_nodeset <- function(x, header = NA, trim = TRUE, fill = FALSE,
 html_table.xml_node <- function(x, header = NA, trim = TRUE,
                                               fill = FALSE, dec = ".") {
 
-  if(grep("Korean",Sys.getlocale())==1){Sys.setlocale("LC_ALL", "English");korean_set<-1}else{korean_set<-0}
+  if(identical(grep("English",Sys.getlocale()),integer(0))){
+    lang<-strsplit(tem,"[=;._]")[[1]]
+    lang<-lang[length(lang)-2]
+    Sys.setlocale("LC_ALL", "English")
+    lang_set<-1}else{lang_set<-0}
 
   stopifnot(html_name(x) == "table")
 
@@ -136,6 +140,6 @@ html_table.xml_node <- function(x, header = NA, trim = TRUE,
   if (length(unique(col_names)) < length(col_names)) {
     warning('At least two columns have the same name')
   }
-  if(korean_set==1){Sys.setlocale("LC_ALL", "Korean")}
+  if(lang_set==1){Sys.setlocale("LC_ALL", lang)}
   df
 }


### PR DESCRIPTION
if locale is korean, html_table function return encoding error.
I got hint to this post below.

http://www.exegetic.biz/blog/2016/08/web-scraping-invalid-multibyte-string/
