### PR TITLE
Replacing deprecated functions in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -56,13 +56,13 @@ The most important functions in rvest are:
   [selectorgadget](http://selectorgadget.com/), make sure to read
   `vignette("selectorgadget")` to learn about it.
 
-* Extract components with `html_tag()` (the name of the tag), `html_text()` 
+* Extract components with `html_name()` (the name of the tag), `html_text()` 
   (all text inside the tag), `html_attr()` (contents of a single attribute) and 
   `html_attrs()` (all attributes).
 
 * (You can also use rvest with XML files: parse with `xml()`, then extract 
   components using `xml_node()`, `xml_attr()`, `xml_attrs()`, `xml_text()` 
-  and `xml_tag()`.)
+  and `xml_name()`.)
 
 * Parse tables into data frames with `html_table()`.
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ The most important functions in rvest are:
 
 -   Select parts of a document using css selectors: `html_nodes(doc, "table td")` (or if you've a glutton for punishment, use xpath selectors with `html_nodes(doc, xpath = "//table//td")`). If you haven't heard of [selectorgadget](http://selectorgadget.com/), make sure to read `vignette("selectorgadget")` to learn about it.
 
--   Extract components with `html_tag()` (the name of the tag), `html_text()` (all text inside the tag), `html_attr()` (contents of a single attribute) and `html_attrs()` (all attributes).
+-   Extract components with `html_name()` (the name of the tag), `html_text()` (all text inside the tag), `html_attr()` (contents of a single attribute) and `html_attrs()` (all attributes).
 
--   (You can also use rvest with XML files: parse with `xml()`, then extract components using `xml_node()`, `xml_attr()`, `xml_attrs()`, `xml_text()` and `xml_tag()`.)
+-   (You can also use rvest with XML files: parse with `xml()`, then extract components using `xml_node()`, `xml_attr()`, `xml_attrs()`, `xml_text()` and `xml_name()`.)
 
 -   Parse tables into data frames with `html_table()`.
 


### PR DESCRIPTION
`html_tag` and `xml_tag` are deprecated but still present in README. Replacing them by `html_name` and `xlm_name`