### PR TITLE
Fix README example after imdb update

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -33,8 +33,8 @@ rating <- lego_movie %>%
 rating
 
 cast <- lego_movie %>%
-  html_nodes("#titleCast .itemprop span") %>%
-  html_text()
+  html_nodes("#titleCast .primary_photo img") %>%
+  html_attr("alt")
 cast
 
 poster <- lego_movie %>%

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ rating
 #> [1] 7.8
 
 cast <- lego_movie %>%
-  html_nodes("#titleCast .itemprop span") %>%
-  html_text()
+  html_nodes("#titleCast .primary_photo img") %>%
+  html_attr("alt")
 cast
 #>  [1] "Will Arnett"     "Elizabeth Banks" "Craig Berry"    
 #>  [4] "Alison Brie"     "David Burrows"   "Anthony Daniels"


### PR DESCRIPTION
It looks like the `imdb` site has changed a bit and broke the cast example in the README. This scrapes the same info from the site.