### PR TITLE
Updated html_text example after IMDb Update

### DIFF
--- a/R/html.R
+++ b/R/html.R
@@ -5,12 +5,12 @@
 #' @inheritParams xml2::xml_text
 #' @export
 #' @examples
-#' movie <- read_html("http://www.imdb.com/title/tt1490017/")
-#' cast <- html_nodes(movie, "#titleCast span.itemprop")
+#' movie <- read_html("https://en.wikipedia.org/wiki/The_Lego_Movie")
+#' cast <- html_nodes(movie, "tr:nth-child(8) .plainlist a")
 #' html_text(cast)
 #' html_name(cast)
 #' html_attrs(cast)
-#' html_attr(cast, "class")
+#' html_attr(cast, "href")
 html_text <- function(x, trim = FALSE) {
   xml2::xml_text(x, trim = trim)
 }

--- a/man/html_text.Rd
+++ b/man/html_text.Rd
@@ -36,10 +36,10 @@ vector; \code{html_attrs}, a list.
 Extract attributes, text and tag name from html.
 }
 \examples{
-movie <- read_html("http://www.imdb.com/title/tt1490017/")
-cast <- html_nodes(movie, "#titleCast span.itemprop")
+movie <- read_html("https://en.wikipedia.org/wiki/The_Lego_Movie")
+cast <- html_nodes(movie, "tr:nth-child(8) .plainlist a")
 html_text(cast)
 html_name(cast)
 html_attrs(cast)
-html_attr(cast, "class")
+html_attr(cast, "href")
 }


### PR DESCRIPTION
AFter the IMDb update there was a fix for the readme #225  but not the `html_text()` documentation. Here I have changed it to pull the cast from Wikipedia's listing as it provides an example similar to the previous one before the update.