### PR TITLE
Update readme files to use xml2::read_html() instead of rvest::html()

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -26,7 +26,7 @@ rvest helps you scrape information from web pages. It is designed to work with [
 
 ```{r, message = FALSE}
 library(rvest)
-lego_movie <- read_html("http://www.imdb.com/title/tt1490017/")
+lego_movie <- xml2::read_html("http://www.imdb.com/title/tt1490017/")
 
 rating <- lego_movie %>% 
   html_nodes("strong span") %>%
@@ -65,7 +65,7 @@ devtools::install_github("tidyverse/rvest")
 The most important functions in rvest are:
 
 * Create an html document from a url, a file on disk or a string containing
-  html with `read_html()`.
+  html with `xml2::read_html()`.
 
 * Select parts of a document using CSS selectors: `html_nodes(doc, "table td")`
   (or if you've a glutton for punishment, use XPath selectors with

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ easy to express common web scraping tasks, inspired by libraries like
 
 ``` r
 library(rvest)
-lego_movie <- read_html("http://www.imdb.com/title/tt1490017/")
+lego_movie <- xml2::read_html("http://www.imdb.com/title/tt1490017/")
 
 rating <- lego_movie %>% 
   html_nodes("strong span") %>%
@@ -68,7 +68,7 @@ devtools::install_github("tidyverse/rvest")
 The most important functions in rvest are:
 
   - Create an html document from a url, a file on disk or a string
-    containing html with `read_html()`.
+    containing html with `xml2::read_html()`.
 
   - Select parts of a document using CSS selectors: `html_nodes(doc,
     "table td")` (or if you’ve a glutton for punishment, use XPath


### PR DESCRIPTION
When using `rvest::html()` to import an HTML document as instructed in README files, the rvest package responds 

```Warning message:
rvest::html' is deprecated.
Use 'xml2::read_html' instead.
See help("Deprecated") 
```

This pull request is a text (not code) edit updating the README files to reflect that.