### PR TITLE
Update form name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,4 +34,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/R/form.R
+++ b/R/form.R
@@ -260,7 +260,7 @@ set_values <- function(form, ...) {
 #' @examples
 #' test <- google_form("1M9B8DsYNFyDjpwSK6ur_bZf8Rv_04ma3rmaaBiveoUI")
 #' f0 <- html_form(test)[[1]]
-#' f1 <- set_values(f0, entry.564397473 = "abc")
+#' f1 <- set_values(f0, entry.1991630528_sentinel = "abc")
 submit_form <- function(session, form, submit = NULL, ...) {
   request <- submit_request(form, submit)
   url <- xml2::url_absolute(form$url, session$url)

--- a/man/submit_form.Rd
+++ b/man/submit_form.Rd
@@ -28,5 +28,5 @@ Submit a form back to the server.
 \examples{
 test <- google_form("1M9B8DsYNFyDjpwSK6ur_bZf8Rv_04ma3rmaaBiveoUI")
 f0 <- html_form(test)[[1]]
-f1 <- set_values(f0, entry.564397473 = "abc")
+f1 <- set_values(f0, entry.1991630528_sentinel = "abc")
 }


### PR DESCRIPTION
I *think* the form name changed in the google form. This updates the example (hopefully) addressing #281 

I had not used `submit_form()` nor `google_form()` before, so please treat with caution. The example now seems to pass CRAN checks