### PR TITLE
Add `convert` arg to html_table() to control whether to run conversion or not.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,8 @@
   `html_table()` now returns a tibble rather than a data frame to be compatible
   with the rest of the tidyverse (#199). Its performance has been considerably
   improved (#237). It also gains a `na.strings` argument to control what values 
-  are converted to `NA` (#107).
+  are converted to `NA` (#107), and a `convert` argument to control whether to
+  run the conversion (#311).
 
 * New `html_form_submit()` allows you to submit a form directly, without 
   needing to create a session (#300).

--- a/R/session.R
+++ b/R/session.R
@@ -233,14 +233,16 @@ html_table.rvest_session <- function(x,
                                trim = TRUE,
                                fill = deprecated(),
                                dec = ".",
-                               na.strings = "NA") {
+                               na.strings = "NA",
+                               convert = TRUE) {
   html_table(
     read_html(x),
     header = header,
     trim = trim,
     fill = fill,
     dec = dec,
-    na.strings = na.strings
+    na.strings = na.strings,
+    convert = convert
   )
 }
 

--- a/R/table.R
+++ b/R/table.R
@@ -16,8 +16,8 @@
 #' @param dec The character used as decimal place marker.
 #' @param na.strings Character vector of values that will be converted to `NA`
 #'    if `convert` is `TRUE`.
-#' @param convert If `TRUE`, will run [`type.convert()`] to convert `NA` and
-#'    numbers.
+#' @param convert If `TRUE`, will run [`type.convert()`] to interpret texts as
+#'    integer, double, or `NA`.
 #' @return
 #' When applied to a single element, `html_table()` returns a single tibble.
 #' When applied to multiple elements or a document, `html_table()` returns

--- a/R/table.R
+++ b/R/table.R
@@ -14,7 +14,10 @@
 #' @param fill Deprecated - missing cells in tables are now always
 #'    automatically filled with `NA`.
 #' @param dec The character used as decimal place marker.
-#' @param na.strings Character vector of values that will be converted to `NA`.
+#' @param na.strings Character vector of values that will be converted to `NA`
+#'    if `convert` is `TRUE`.
+#' @param convert If `TRUE`, will run [`type.convert()`] to convert `NA` and
+#'    numbers.
 #' @return
 #' When applied to a single element, `html_table()` returns a single tibble.
 #' When applied to multiple elements or a document, `html_table()` returns
@@ -57,7 +60,8 @@ html_table <- function(x,
                        trim = TRUE,
                        fill = deprecated(),
                        dec = ".",
-                       na.strings = "NA"
+                       na.strings = "NA",
+                       convert = TRUE
   ) {
 
   UseMethod("html_table")
@@ -69,7 +73,8 @@ html_table.xml_document <- function(x,
                                     trim = TRUE,
                                     fill = deprecated(),
                                     dec = ".",
-                                    na.strings = "NA") {
+                                    na.strings = "NA",
+                                    convert = TRUE) {
   tables <- xml2::xml_find_all(x, ".//table")
   html_table(
     tables,
@@ -77,7 +82,8 @@ html_table.xml_document <- function(x,
     trim = trim,
     fill = fill,
     dec = dec,
-    na.strings = na.strings
+    na.strings = na.strings,
+    convert = convert
   )
 }
 
@@ -87,7 +93,8 @@ html_table.xml_nodeset <- function(x,
                                    trim = TRUE,
                                    fill = deprecated(),
                                    dec = ".",
-                                   na.strings = "NA") {
+                                   na.strings = "NA",
+                                   convert = TRUE) {
   lapply(
     x,
     html_table,
@@ -95,7 +102,8 @@ html_table.xml_nodeset <- function(x,
     trim = trim,
     fill = fill,
     dec = dec,
-    na.strings = na.strings
+    na.strings = na.strings,
+    convert = convert
   )
 }
 
@@ -105,7 +113,8 @@ html_table.xml_node <- function(x,
                                 trim = TRUE,
                                 fill = deprecated(),
                                 dec = ".",
-                                na.strings = "NA") {
+                                na.strings = "NA",
+                                convert = TRUE) {
 
   if (lifecycle::is_present(fill) && !isTRUE(fill)) {
     lifecycle::deprecate_warn(
@@ -130,12 +139,19 @@ html_table.xml_node <- function(x,
     col_names <- paste0("X", seq_len(ncol(out)))
   }
 
-  # Convert matrix to list to data frame
-  df <- lapply(seq_len(ncol(out)), function(i) {
-    utils::type.convert(out[, i], as.is = TRUE, dec = dec, na.strings = na.strings)
-  })
-  names(df) <- col_names
-  tibble::as_tibble(df, .name_repair = "minimal")
+  if (isTRUE(convert)) {
+    # With type conversion, convert matrix to list to data frame
+    df <- lapply(seq_len(ncol(out)), function(i) {
+      utils::type.convert(out[, i], as.is = TRUE, dec = dec, na.strings = na.strings)
+    })
+
+    names(df) <- col_names
+    tibble::as_tibble(df, .name_repair = "minimal")
+  } else {
+    # Without type conversion, cast matrix to data frame directly
+    colnames(out) <- col_names
+    tibble::as_tibble(out, .name_repair = "minimal")
+  }
 }
 
 # Table fillng algorithm --------------------------------------------------

--- a/R/table.R
+++ b/R/table.R
@@ -139,19 +139,16 @@ html_table.xml_node <- function(x,
     col_names <- paste0("X", seq_len(ncol(out)))
   }
 
-  if (isTRUE(convert)) {
-    # With type conversion, convert matrix to list to data frame
-    df <- lapply(seq_len(ncol(out)), function(i) {
-      utils::type.convert(out[, i], as.is = TRUE, dec = dec, na.strings = na.strings)
-    })
+  colnames(out) <- col_names
+  out <- tibble::as_tibble(out, .name_repair = "minimal")
 
-    names(df) <- col_names
-    tibble::as_tibble(df, .name_repair = "minimal")
-  } else {
-    # Without type conversion, cast matrix to data frame directly
-    colnames(out) <- col_names
-    tibble::as_tibble(out, .name_repair = "minimal")
+  if (isTRUE(convert)) {
+    out[] <- lapply(out, function(x) {
+        utils::type.convert(x, as.is = TRUE, dec = dec, na.strings = na.strings)
+    })
   }
+
+  out
 }
 
 # Table fillng algorithm --------------------------------------------------

--- a/R/table.R
+++ b/R/table.R
@@ -140,15 +140,15 @@ html_table.xml_node <- function(x,
   }
 
   colnames(out) <- col_names
-  out <- tibble::as_tibble(out, .name_repair = "minimal")
+  df <- tibble::as_tibble(out, .name_repair = "minimal")
 
   if (isTRUE(convert)) {
-    out[] <- lapply(out, function(x) {
+    df[] <- lapply(df, function(x) {
         utils::type.convert(x, as.is = TRUE, dec = dec, na.strings = na.strings)
     })
   }
 
-  out
+  df
 }
 
 # Table fillng algorithm --------------------------------------------------

--- a/man/html_table.Rd
+++ b/man/html_table.Rd
@@ -10,7 +10,8 @@ html_table(
   trim = TRUE,
   fill = deprecated(),
   dec = ".",
-  na.strings = "NA"
+  na.strings = "NA",
+  convert = TRUE
 )
 }
 \arguments{
@@ -31,7 +32,11 @@ automatically filled with \code{NA}.}
 
 \item{dec}{The character used as decimal place marker.}
 
-\item{na.strings}{Character vector of values that will be converted to \code{NA}.}
+\item{na.strings}{Character vector of values that will be converted to \code{NA}
+if \code{convert} is \code{TRUE}.}
+
+\item{convert}{If \code{TRUE}, will run \code{\link[=type.convert]{type.convert()}} to convert \code{NA} and
+numbers.}
 }
 \value{
 When applied to a single element, \code{html_table()} returns a single tibble.

--- a/man/html_table.Rd
+++ b/man/html_table.Rd
@@ -35,8 +35,8 @@ automatically filled with \code{NA}.}
 \item{na.strings}{Character vector of values that will be converted to \code{NA}
 if \code{convert} is \code{TRUE}.}
 
-\item{convert}{If \code{TRUE}, will run \code{\link[=type.convert]{type.convert()}} to convert \code{NA} and
-numbers.}
+\item{convert}{If \code{TRUE}, will run \code{\link[=type.convert]{type.convert()}} to interpret texts as
+integer, double, or \code{NA}.}
 }
 \value{
 When applied to a single element, \code{html_table()} returns a single tibble.

--- a/tests/testthat/_snaps/table.md
+++ b/tests/testthat/_snaps/table.md
@@ -50,6 +50,13 @@
       <int>
     1     2
 
+# no conversion
+
+    # A tibble: 1 x 2
+      x     y    
+      <chr> <chr>
+    1 001   100.0
+
 # fill = FALSE is deprecated
 
     Code

--- a/tests/testthat/test-table.R
+++ b/tests/testthat/test-table.R
@@ -134,6 +134,17 @@ test_that("passes arguments to type.convert", {
   expect_equal(table$y, 1.2)
 })
 
+test_that("no conversion", {
+  html <- minimal_html('
+    <table>
+      <tr><th>x<th>y
+      <tr><td>001<td>100.0
+    </table>
+  ')
+  table <- html_table(html, convert = FALSE)[[1]]
+  expect_snapshot_output(table)
+})
+
 test_that("fill = FALSE is deprecated", {
   html <- minimal_html('
     <table>


### PR DESCRIPTION
Fix #311 

I chose `convert` as the argument name because it's used some of tidyr's functions.

``` r
library(tibble)

d <- tibble(code = c("001", "002", "101", "102"),
            label = c("apple", "banana", "lemon", "orange"))

devtools::load_all("~/repo/rvest/")
#> Loading rvest

table_html <- knitr::kable(d, format = "html")
table_html <- as.character(table_html)

h <- table_html %>% 
  read_html()


html_table(h)
#> [[1]]
#> # A tibble: 4 x 2
#>    code label 
#>   <int> <chr> 
#> 1     1 apple 
#> 2     2 banana
#> 3   101 lemon 
#> 4   102 orange

html_table(h, convert = FALSE)
#> [[1]]
#> # A tibble: 4 x 2
#>   code  label 
#>   <chr> <chr> 
#> 1 001   apple 
#> 2 002   banana
#> 3 101   lemon 
#> 4 102   orange
```

<sup>Created on 2021-02-06 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>