### PR TITLE
Make sure back then forward is a roundtrip

### DIFF
--- a/R/session.R
+++ b/R/session.R
@@ -152,9 +152,10 @@ session_back <- function(x) {
 
   url <- x$back[[1]]
   x$back <- x$back[-1]
+  old_url <- x$url
 
   x <- session_get(x, url)
-  x$forward <- c(x$url, x$forward)
+  x$forward <- c(old_url, x$forward)
   x
 }
 
@@ -168,10 +169,11 @@ session_forward <- function(x) {
   }
 
   url <- x$forward[[1]]
+  old_url <- x$url
 
   x <- session_get(x, url)
   x$forward <- x$forward[-1]
-  x$back <- c(x$url, x$backs)
+  x$back <- c(old_url, x$back)
   x
 }
 

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -57,9 +57,11 @@ test_that("can navigate back and forward", {
   expect_equal(s$back, "http://hadley.nz/")
   expect_equal(s$forward, character())
 
+  expect_equal(session_forward(session_back(s))$url, s$url)
+
   s <- session_back(s)
   expect_equal(s$back, character())
-  expect_equal(s$forward, "http://hadley.nz/")
+  expect_equal(s$forward, "http://hadley.nz/hadley-wickham.jpg")
 
   s <- session_forward(s)
   expect_equal(s$back, "http://hadley.nz/")


### PR DESCRIPTION
Fixes issue #313:

* `session_back()` and `session_forward()` were using URL after navigation rather than original URL to update history elements.
* Added a roundtrip test.  Existing test for `session_back()` was incorrect, fixed.