### PR TITLE
Make html_table() handle blank rowspan and colspan attributes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 
 ## New features
 
+* `html_table()` correctly handles tables with cells that contain blank values 
+  for `rowspan` and/or `colspan`, so that e.g. `<td rowspan="">` is parsed as 
+  `<td rowspan=1>` (@epiben, #323).
+
 * New `html_text2()` provides a more natural rendering of HTML nodes into text,
   converting `<br>` into "\n", and removing non-significant whitespace (#175). 
   By default, it also converts `&nbsp;` into regular spaces, which you can 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,13 @@
 # rvest (development version)
 
+* `html_table()` correctly handles tables with cells that contain blank values 
+  for `rowspan` and/or `colspan`, so that e.g. `<td rowspan="">` is parsed as 
+  `<td rowspan=1>` (@epiben, #323).
+
 # rvest 1.0.0
 (to be released as rvest 1.0.0)
 
 ## New features
-
-* `html_table()` correctly handles tables with cells that contain blank values 
-  for `rowspan` and/or `colspan`, so that e.g. `<td rowspan="">` is parsed as 
-  `<td rowspan=1>` (@epiben, #323).
 
 * New `html_text2()` provides a more natural rendering of HTML nodes into text,
   converting `<br>` into "\n", and removing non-significant whitespace (#175). 

--- a/R/table.R
+++ b/R/table.R
@@ -169,9 +169,9 @@ table_fill <- function(cells, trim = TRUE) {
       next
     }
 
-    rowspan <- as.integer(html_attr(row, "rowspan", default = "1"))
+    rowspan <- as.integer(html_attr(row, "rowspan", default = NA_character_))
     rowspan[is.na(rowspan)] <- 1
-    colspan <- as.integer(html_attr(row, "colspan", default = "1"))
+    colspan <- as.integer(html_attr(row, "colspan", default = NA_character_))
     colspan[is.na(colspan)] <- 1
     text <- html_text(row)
     if (isTRUE(trim)) {

--- a/R/table.R
+++ b/R/table.R
@@ -170,7 +170,9 @@ table_fill <- function(cells, trim = TRUE) {
     }
 
     rowspan <- as.integer(html_attr(row, "rowspan", default = "1"))
+    rowspan[is.na(rowspan)] <- 1
     colspan <- as.integer(html_attr(row, "colspan", default = "1"))
+    colspan[is.na(colspan)] <- 1
     text <- html_text(row)
     if (isTRUE(trim)) {
       text <- gsub("^[[:space:]\u00a0]+|[[:space:]\u00a0]+$", "", text)

--- a/tests/testthat/_snaps/table.md
+++ b/tests/testthat/_snaps/table.md
@@ -43,6 +43,22 @@
     3    NA     2    NA
     4    NA     2    NA
 
+# can handle blank colspans
+
+    # A tibble: 2 x 2
+          x     y
+      <int> <int>
+    1     1     2
+    2     3     3
+
+# can handle blank rowspans
+
+    # A tibble: 2 x 2
+          x     y
+      <int> <int>
+    1     1     2
+    2     3     3
+
 # can handle empty row
 
     # A tibble: 1 x 1

--- a/tests/testthat/test-table.R
+++ b/tests/testthat/test-table.R
@@ -85,6 +85,36 @@ test_that("can handle trailing rowspans", {
 
 })
 
+test_that("can handle blank colspans", {
+  html <- minimal_html('
+    <table>
+      <tr><th>x</th><th>y</th></tr>
+		  <tr>
+        <td colspan="">1</td>
+        <td colspan="">2</td>
+      </tr>
+      <tr><td colspan=2>3</td></tr>
+    </table>
+  ')
+  table <- html_table(html)[[1]]
+  expect_snapshot_output(table)
+})
+
+test_that("can handle blank rowspans", {
+  html <- minimal_html('
+    <table>
+      <tr><th>x</th><th>y</th></tr>
+       <tr>
+         <td rowspan="">1</td>
+         <td rowspan="">2</td>
+       </tr>
+       <tr><td colspan=2>3</td></tr>
+     </table>
+  ')
+  table <- html_table(html)[[1]]
+  expect_snapshot_output(table)
+})
+
 test_that("can handle empty row", {
   html <- minimal_html('
     <table>


### PR DESCRIPTION
Solves https://github.com/tidyverse/rvest/issues/322.
With these additions, code such as `<table><tr><td rowspan=''>cell content</td></tr></table>` will produce the expected result. The issue presents several other examples.