### PR TITLE
Handle blank tables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rvest (development version)
 
+* `html_table()` converts empty tables to empty tibbles (@epiben, #327).
+
 * `html_table()` correctly handles tables with cells that contain blank values 
   for `rowspan` and/or `colspan`, so that e.g. `<td rowspan="">` is parsed as 
   `<td rowspan=1>` (@epiben, #323).

--- a/R/table.R
+++ b/R/table.R
@@ -170,7 +170,9 @@ table_fill <- function(cells, trim = TRUE) {
     }
 
     rowspan <- as.integer(html_attr(row, "rowspan", default = "1"))
+    rowspan[is.na(rowspan)] <- 1
     colspan <- as.integer(html_attr(row, "colspan", default = "1"))
+    colspan[is.na(colspan)] <- 1
     text <- html_text(row)
     if (isTRUE(trim)) {
       text <- gsub("^[[:space:]\u00a0]+|[[:space:]\u00a0]+$", "", text)

--- a/R/table.R
+++ b/R/table.R
@@ -127,6 +127,11 @@ html_table.xml_node <- function(x,
   ns <- xml2::xml_ns(x)
   rows <- xml2::xml_find_all(x, ".//tr", ns = ns)
   cells <- lapply(rows, xml2::xml_find_all, ".//td|.//th", ns = ns)
+
+  if (length(cells) == 0) {
+    return(tibble::tibble())
+  }
+
   out <- table_fill(cells, trim = trim)
 
   if (is.na(header)) {

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -29,6 +29,8 @@ reference:
 
 news:
   releases:
+  - text: "Version 1.0.0"
+    href: https://www.tidyverse.org/blog/2021/03/rvest-1-0-0/
   - text: "Version 0.3.0"
     href: https://blog.rstudio.com/2015/09/24/rvest-0-3-0/
   - text: "Version 0.1.0"

--- a/tests/testthat/_snaps/table.md
+++ b/tests/testthat/_snaps/table.md
@@ -83,3 +83,7 @@
     Code
       . <- html_table(html, fill = TRUE)
 
+# can handle empty tables
+
+    # A tibble: 0 x 0
+

--- a/tests/testthat/test-table.R
+++ b/tests/testthat/test-table.R
@@ -189,3 +189,9 @@ test_that("fill = FALSE is deprecated", {
     . <- html_table(html, fill = TRUE)
   })
 })
+
+test_that("can handle empty tables", {
+  html <- minimal_html('<table></table>')
+  table <- html_table(html)[[1]]
+  expect_snapshot_output(table)
+})


### PR DESCRIPTION
Fixes #324. Enables `html_table` to correctly convert empty tables to empty tibbles. Empty tables are a bit of an oddity, but they do exist and this way at least they're handled. Will add a NEWS entry once I have the PR id.