### PR TITLE
Fix typo in read_html_live() docs

### DIFF
--- a/R/live.R
+++ b/R/live.R
@@ -27,7 +27,7 @@
 #' # When we retrieve the raw HTML for this site, it doesn't contain the
 #' # data we're interested in:
 #' static <- read_html("https://www.forbes.com/top-colleges/")
-#' sess %>% html_elements(".TopColleges2023_tableRow__BYOSU")
+#' static %>% html_elements(".TopColleges2023_tableRow__BYOSU")
 #'
 #' # Instead, we need to run the site in a real web browser, causing it to
 #' # download a JSON file and then dynamically generate the html:

--- a/man/read_html_live.Rd
+++ b/man/read_html_live.Rd
@@ -36,7 +36,7 @@ on your machine.
 # When we retrieve the raw HTML for this site, it doesn't contain the
 # data we're interested in:
 static <- read_html("https://www.forbes.com/top-colleges/")
-sess \%>\% html_elements(".TopColleges2023_tableRow__BYOSU")
+static \%>\% html_elements(".TopColleges2023_tableRow__BYOSU")
 
 # Instead, we need to run the site in a real web browser, causing it to
 # download a JSON file and then dynamically generate the html:


### PR DESCRIPTION
The first example in the `read_html_live()` docs is a deliberately non-working example of scraping a dynamic site. 

However, it referred to the `sess` object (created later in the example) rather than the `static` object, which is what I believe was intended. 

This tiny PR fixes this apparent typo.