### PR TITLE
Added a vignette that lists CRAN packages from its website.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docs/
 .Rhistory
 .RData
 inst/doc
+.DS_Store

--- a/vignettes/cran_packages.Rmd
+++ b/vignettes/cran_packages.Rmd
@@ -24,7 +24,12 @@ table
 ```
 ```{r, echo = FALSE, results = "asis"}
  
+
  
-table %>%
-    dplyr::filter( grepl("dplyr" , X2 ) )
+has_dplyr_keyword<- function(x) {   
+    isTRUE( grepl("dplyr" , x ) )
+}
+
+table[ Vectorize( has_dplyr_keyword)(table$X2) , ]
+
 ```

--- a/vignettes/cran_packages.Rmd
+++ b/vignettes/cran_packages.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Star Wars films"
+title: "CRAN packages"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Cran Packages}

--- a/vignettes/cran_packages.Rmd
+++ b/vignettes/cran_packages.Rmd
@@ -1,0 +1,30 @@
+---
+title: "Star Wars films"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Cran Packages}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+This vignette lists CRAN packages from its website.
+
+
+```{r, echo = FALSE, results = "asis"}
+library(rvest)
+
+cran_url <- "https://cran.r-project.org/web/packages/available_packages_by_name.html"
+
+table  <- read_html( cran_url )  %>%
+    html_element("table")  %>%
+    html_table()
+
+table
+
+ 
+```
+```{r, echo = FALSE, results = "asis"}
+ 
+ 
+table %>%
+    dplyr::filter( grepl("dplyr" , X2 ) )
+```


### PR DESCRIPTION
This vignette lists CRAN packages from its website.

[CranRpoject](https://cran.r-project.org/web/packages/available_packages_by_name.html)
 