### PR TITLE
Wait in click()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # rvest (development version)
 
 * New example vignette displays the same starwars data but rendered dynamically using JS, so you need to use `read_html_live()` to get the data.
+* The `click()` method for `LiveHTML` objects gains a `new_page` argument to deal with situations where a click loads a new web page (@jonthegeek, #405).
 
 # rvest 1.0.4
 

--- a/man/LiveHTML.Rd
+++ b/man/LiveHTML.Rd
@@ -122,7 +122,7 @@ Extract HTML elements from the current page.
 \subsection{Method \code{click()}}{
 Simulate a click on an HTML element.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{LiveHTML$click(css, n_clicks = 1)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{LiveHTML$click(css, n_clicks = 1, new_page = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -131,6 +131,9 @@ Simulate a click on an HTML element.
 \item{\code{css}}{CSS selector or xpath expression.}
 
 \item{\code{n_clicks}}{Number of clicks}
+
+\item{\code{new_page}}{Whether to wait for a new page to load, such as after
+clicking a link.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -7,12 +7,12 @@
       <session> https://hadley.nz/
         Status: 200
         Type:   text/html; charset=utf-8
-        Size:   821273
+        Size:   821905
     Code
       expect_true(is.session(s))
       s <- session_follow_link(s, css = "p a")
     Message
-      Navigating to <http://rstudio.com>.
+      Navigating to <https://posit.co>.
     Code
       session_history(s)
     Output

--- a/tests/testthat/html/navigate1.html
+++ b/tests/testthat/html/navigate1.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Navigate 1</title>
+</head>
+<body>
+  <a href="navigate2.html">Navigate to Page 2</a>
+</body>

--- a/tests/testthat/html/navigate2.html
+++ b/tests/testthat/html/navigate2.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Navigate 2</title>
+</head>
+<body>
+  <p>Success!</p>
+</body>

--- a/tests/testthat/test-live.R
+++ b/tests/testthat/test-live.R
@@ -50,6 +50,14 @@ test_that("can click a button", {
   expect_equal(html_text(html_element(sess, "p")), "double clicked")
 })
 
+test_that("can find elements after click that navigates", {
+  skip_if_no_chromote()
+
+  sess <- read_html_live(html_test_path("navigate1"))
+  sess$click("a", new_page = TRUE)
+  expect_equal(html_text2(html_element(sess, "p")), "Success!")
+})
+
 test_that("can scroll in various ways", {
   skip_if_no_chromote()
 
@@ -88,6 +96,16 @@ test_that("can press special keys",{
   expect_equal(html_text(html_element(sess, "#keyInfo")), "]/BracketRight")
 })
 
+test_that("gracefully errors on missing root node", {
+  skip_if_no_chromote()
+
+  sess <- read_html_live(html_test_path("navigate1"))
+  sess$click("a")
+  expect_error(
+    html_element(sess, "p"),
+    class = "rvest_error-missing_node"
+  )
+})
 
 # as_key_desc -------------------------------------------------------------
 


### PR DESCRIPTION
Closes #405.

I tried to make this automatic, and got it working some of the time, but I couldn't find a way to detect that something *might* change, and thus wait in that situation. I tried to make it as clear as possible for users to be able to fix this. Once a strategy is agreed on, the same strategy should probably be applied to other methods.

An approach I worked on but failed to finalize would be to either wait for a `loadEventFired()` event *or* time out (probably after a relatively brief time, and only if no events occur in that window, or something along those lines). I couldn't find a clean way to check if anything is in progress and thus wait if so; if we're waiting for a loadEventFired that never fires, we'll introduced a new error for many click events.

I also tried adding `private$refresh_root()` as a callback on `loadEventFired()`, which might be a useful approach but it still doesn't solve the issue of users not waiting for that to occur before executing their next step.

I like this better than status quo (since it makes it *possible* to deal with these situations), but I'm not sure that it's quite there yet.