### PR TITLE
Add xpath argument to LiveHTML click() method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,4 +42,4 @@ Config/testthat/parallel: true
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/man/LiveHTML.Rd
+++ b/man/LiveHTML.Rd
@@ -122,13 +122,13 @@ Extract HTML elements from the current page.
 \subsection{Method \code{click()}}{
 Simulate a click on an HTML element.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{LiveHTML$click(css, n_clicks = 1)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{LiveHTML$click(css, xpath, n_clicks = 1)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{css}}{CSS selector or xpath expression.}
+\item{\code{css, xpath}}{CSS selector or xpath expression.}
 
 \item{\code{n_clicks}}{Number of clicks}
 }

--- a/tests/testthat/test-live.R
+++ b/tests/testthat/test-live.R
@@ -43,10 +43,14 @@ test_that("can click a button", {
   skip_if_no_chromote()
 
   sess <- read_html_live(html_test_path("click"))
-  sess$click("button")
+  sess$click(css = "button")
   expect_equal(html_text(html_element(sess, "p")), "clicked")
 
-  sess$click("button", 2)
+  sess <- read_html_live(html_test_path("click"))
+  sess$click(xpath = "//button")
+  expect_equal(html_text(html_element(sess, "p")), "clicked")
+
+  sess$click(css = "button", n_clicks = 2)
   expect_equal(html_text(html_element(sess, "p")), "double clicked")
 })
 


### PR DESCRIPTION
Noticed that the click() method does not accept xpath even though the documentation mentions it. Tried to add a simple fix. This is my first ever pull request so apologies if I messed something up!