### PR TITLE
LiveHTML: use dynamic root ID

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,6 @@ VignetteBuilder:
     knitr
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
-Config/testthat/parallel: true
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,7 @@ VignetteBuilder:
     knitr
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
+Config/testthat/parallel: true
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rvest (development version)
 
+* Fixes `LiveHTML` objects returning 'could not find node with given id' errors if a page navigation occurred after a `$click()` event (#405).
+
 * New example vignette displays the same starwars data but rendered dynamically using JS, so you need to use `read_html_live()` to get the data.
 
 # rvest 1.0.4

--- a/R/live.R
+++ b/R/live.R
@@ -91,8 +91,6 @@ LiveHTML <- R6::R6Class(
       p <- self$session$Page$loadEventFired(wait_ = FALSE)
       self$session$Page$navigate(url, wait_ = FALSE)
       self$session$wait_for(p)
-
-      private$root_id <- self$session$DOM$getDocument(0)$root$nodeId
     },
 
     #' @description Called when `print()`ed
@@ -202,7 +200,7 @@ LiveHTML <- R6::R6Class(
 
       # https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo
       private$call_node_method(
-        private$root_id,
+        private$root_id(),
         paste0(".documentElement.scrollTo(", left, ", ", top, ")")
       )
       invisible(self)
@@ -262,8 +260,9 @@ LiveHTML <- R6::R6Class(
   ),
 
   private = list(
-    root_id = NULL,
-
+    root_id = function() {
+      self$session$DOM$getDocument()$root$nodeId
+    },
     finalize = function() {
       self$session$close()
     },
@@ -272,7 +271,6 @@ LiveHTML <- R6::R6Class(
       if (new_chromote && !self$session$is_active()) {
         suppressMessages({
           self$session <- self$session$respawn()
-          private$root_id <- self$session$DOM$getDocument(0)$root$nodeId
         })
       }
     },
@@ -293,7 +291,7 @@ LiveHTML <- R6::R6Class(
     find_nodes = function(css, xpath) {
       check_exclusive(css, xpath)
       if (!missing(css)) {
-        unlist(self$session$DOM$querySelectorAll(private$root_id, css)$nodeIds)
+        unlist(self$session$DOM$querySelectorAll(private$root_id(), css)$nodeIds)
       } else {
         search <- glue::glue("
           (function() {{

--- a/tests/testthat/html/navigate1.html
+++ b/tests/testthat/html/navigate1.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Navigate 1</title>
+</head>
+<body>
+  <a href="navigate2.html">Navigate to Page 2</a>
+</body>

--- a/tests/testthat/html/navigate2.html
+++ b/tests/testthat/html/navigate2.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Navigate 2</title>
+</head>
+<body>
+  <p>Success!</p>
+</body>

--- a/tests/testthat/test-live.R
+++ b/tests/testthat/test-live.R
@@ -88,6 +88,13 @@ test_that("can press special keys",{
   expect_equal(html_text(html_element(sess, "#keyInfo")), "]/BracketRight")
 })
 
+test_that("can find elements after click that navigates", {
+  skip_if_no_chromote()
+
+  sess <- read_html_live(html_test_path("navigate1"))
+  sess$click("a")
+  expect_equal(html_text2(html_element(sess, "p")), "Success!")
+})
 
 # as_key_desc -------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #405.

I discussed with @schloerke, and this is very much his suggestion / solution.

- The document root ID should always be retrieved dynamically rather than stored within the R6 object as it's subject to change (as we've discovered in #405).

- In Shinytest2, there is an [equivalent helper](https://github.com/rstudio/shinytest2/blob/4e6de2a46e05698b4fa943487ffb66c7d8821021/R/chromote-methods.R#L202C1-L208C1) to retrieve the root ID.

- This PR makes `private$root_id` a function, so it is now always called as `private$root_id()`. This ensures that we never have a stale root id.

Should check cleanly after #445 is merged.

FYI @jonthegeek this is a simpler version of what you were attempting in #413 - you also had the right idea with `private$refresh_root()`.

@hadley for your review, thanks!