### PR TITLE
Fix and test for new libxml2 2.14

### DIFF
--- a/.github/workflows/distros.yml
+++ b/.github/workflows/distros.yml
@@ -1,0 +1,38 @@
+name: Distros
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rhel:
+    runs-on: ubuntu-24.04${{matrix.arch=='arm64' && '-arm' || ''}}
+    name: ${{ matrix.distro }} ${{ matrix.arch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [ 'rocky-8', 'rocky-9', 'debian-13', 'debian-14']
+        arch: [ 'amd64', 'arm64' ]
+    container:
+      image: ghcr.io/r-devel/${{ matrix.distro }}:latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          args: '"--no-manual"'
+        env:
+          NOT_CRAN: false
+          _R_CHECK_DOC_SIZES_: FALSE
+          LANG: en_US.UTF-8

--- a/tests/testthat/test-form.R
+++ b/tests/testthat/test-form.R
@@ -32,7 +32,7 @@ test_that("has useful print method", {
 
 
 test_that("select options are named character vector", {
-  select <- minimal_html("select parsing", '
+  select <- minimal_html('
     <form>
       <select name="x">
         <option value="1">a</option>
@@ -46,7 +46,7 @@ test_that("select options are named character vector", {
 })
 
 test_that("select values are inherited from names", {
-  page <- minimal_html("optional values", '
+  page <- minimal_html('
     <select name="b" id="a">
       <option value="1">x</option>
       <option>y</option>
@@ -58,7 +58,7 @@ test_that("select values are inherited from names", {
 })
 
 test_that("parse_fields gets the button", {
-  select <- minimal_html("button test", '
+  select <- minimal_html('
     <form>
       <button type="submit">Click me</button>
     </form>
@@ -77,7 +77,7 @@ test_that("handles different encoding types", {
 })
 
 test_that("validates its inputs", {
-  select <- minimal_html("button test", '
+  select <- minimal_html('
     <form>
       <button type="submit">Click me</button>
     </form>


### PR DESCRIPTION
Recent versions of libxml2 have some changes, making it a bit more strict. This CI will reproduce a problem that currently happens on CRAN because Debian-14 includes [libxml2 2.14.5](https://packages.debian.org/forky/libxml2-dev).

While we're at it, we also test with some more versions of libxml2.