### PR TITLE
fix #417

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,7 +5,7 @@ new_chromote <- NULL
     new_chromote <<- utils::packageVersion("chromote") >= "0.1.2.9000"
   } else {
     # If chromote is not installed yet, assume it's not new to be safe.
-    new_chromote <- FALSE
+    new_chromote <<- FALSE
   }
 
   invisible()


### PR DESCRIPTION
I ran into #417 today on a new system. I figured out it happens when chromote is installed only after attaching rvest (which is not unlikely as the user is asked to install it when it's missing):

``` r
rlang::is_installed("chromote")
#> [1] FALSE
library(rvest)
install.packages("chromote")
#> Installing package into '/home/johannes/R/x86_64-pc-linux-gnu-library/4.5'
#> (as 'lib' is unspecified)
sess <- rvest::read_html_live('https://www.forbes.com/top-colleges/')
message('curosr at ', sess$get_scroll_position()$y)
#> Error in new_chromote && !self$session$is_active(): invalid 'x' type in 'x && y'
```

<sup>Created on 2025-11-17 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

The issue is that in this case, `new_chromote` was previously only assigned locally.
